### PR TITLE
fix: use ows4R's built-in thing for bbox

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -239,20 +239,7 @@ emdn_get_coverage_dim_coefs <- function(
 #' as the coverage.
 #' @export
 emdn_get_bbox <- function(summary) {
-  # summary$getBoundingBox()$BoundingBox$getBBOX()
-  boundaries <- summary$getDescription()$boundedBy
-  upper <- unlist(c(boundaries$upperCorner))
-  lower <- unlist(c(boundaries$lowerCorner))
-
-  sf::st_bbox(
-    c(
-      xmin = lower[2L],
-      xmax = upper[2L],
-      ymin = lower[1L],
-      ymax = upper[1L]
-    ),
-    crs = extr_bbox_crs(summary)
-  )
+  summary$getBoundingBox()$BoundingBox$getBBOX()
 }
 
 #' @describeIn emdn_get_bbox Get the bounding box (geographic extent) of a


### PR DESCRIPTION
Fix #55 

With this branch

``` r
devtools::load_all()
#> ℹ Loading emodnet.wcs
#> Loading ISO 19139 XML schemas...
#> 
#> Loading ISO 19115-3 XML schemas...
#> 
#> Loading ISO 19139 codelists...
Ewcs <- emdn_init_wcs_client("human_activities")
#> ✔ WCS client created succesfully
#> ℹ Service: <https://ows.emodnet-humanactivities.eu/wcs>
#> ℹ Service: "2.0.1"
emdn_get_bbox(emdn_get_coverage_summaries(Ewcs, "emodnet__vesseldensity_all")[[
  1
]])
#>     xmin     ymin     xmax     ymax 
#> -9763441  1684719 10868459 22822360
```

<sup>Created on 2025-08-20 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

So like

```
<ows:BoundingBox crs="http://www.opengis.net/def/crs/EPSG/0/3857">
<ows:LowerCorner>-9763441.130289372 1684718.7349552144</ows:LowerCorner>
<ows:UpperCorner>1.086845880678606E7 2.28223599215428E7</ows:UpperCorner>
</ows:BoundingBox>
```

@pepijn-devries I'd appreciate your feedback on this PR too when you get a chance. Thank you!