### PR TITLE
Only assign crs to bbox when it's not there yet

### DIFF
--- a/R/coverage.R
+++ b/R/coverage.R
@@ -105,7 +105,7 @@ emdn_get_coverage <- function(
   ]]
   if (crs != coverage_crs) {
     user_bbox <- sf::st_as_sfc(sf::st_bbox(bbox))
-    if (is.na(sf::st_crs(user_bbox)))
+    if (is.na(sf::st_crs(user_bbox))) {
       sf::st_crs(user_bbox) <- crs
     }
     bbox <- sf::st_as_sfc(sf::st_bbox(user_bbox)) |>


### PR DESCRIPTION
Consider this case, where the user has already specified the crs of the bounding box:

```r
library(emodnet.wcs)
wcs <- emdn_init_wcs_client(service = "human_activities")

my_bbox <-
    sf::st_bbox(c(xmin = 484177.9, ymin = 6957617.3,
                  xmax = 1035747, ymax = 7308616.2), crs = 3857)

cov <- emdn_get_coverage(wcs,
                         bbox = my_bbox,
                         coverage_id = "emodnet__vesseldensity_all",
                         nil_values_as_na = FALSE)
```

It will fail as it will try to replace the existing crs. So check if the bbox has a crs before replacing it.